### PR TITLE
LUT-32138: Allow configuration of timetolive and idletimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
+![](https://dev.lutece.paris.fr/jenkins/buildStatus/icon?job=tech-library-httpaccess-deploy)
+[![Alerte](https://dev.lutece.paris.fr/sonar/api/project_badges/measure?project=fr.paris.lutece.plugins%3Alibrary-httpaccess&metric=alert_status)](https://dev.lutece.paris.fr/sonar/dashboard?id=fr.paris.lutece.plugins%3Alibrary-httpaccess)
+[![Line of code](https://dev.lutece.paris.fr/sonar/api/project_badges/measure?project=fr.paris.lutece.plugins%3Alibrary-httpaccess&metric=ncloc)](https://dev.lutece.paris.fr/sonar/dashboard?id=fr.paris.lutece.plugins%3Alibrary-httpaccess)
+[![Coverage](https://dev.lutece.paris.fr/sonar/api/project_badges/measure?project=fr.paris.lutece.plugins%3Alibrary-httpaccess&metric=coverage)](https://dev.lutece.paris.fr/sonar/dashboard?id=fr.paris.lutece.plugins%3Alibrary-httpaccess)
 
-#Library HttpAccess
+# Library HttpAccess
 
-##Introduction
+## Introduction
 
 This library provides simplified methods to perform HTTP requests (GET, POST, ...) and to pass through proxies notably based on NTLM authentications.
 
 Plugins should be based primarily on the library so to pool configuration.
 
-##Configuration
+## Configuration
 
 Configuration is defined in the `WEB-INF/conf/plugins/httpaccess.properties` .
-```
 
+```
 ################################################################
 ## Proxy settings
 httpAccess.proxyHost=
@@ -34,12 +38,25 @@ httpAccess.connexionTimeout=
 httpAccess.socketTimeout=
 #Http responses code authorized (200->OK,201 ->Created,...)
 httpAccess.responsesCodeAuthorized=200,201,202,203,204,205,206,207,210
-                    
+
+# Connection pool configuration
+
+# Maximum total number of connections in the pool; optional
+#httpAccess.connectionPoolMaxTotalConnections=
+# Maximum number of connections per host in the pool; optional
+#httpAccess.connectionPoolMaxConnectionsPerHost
+# Time to live of a connection in the pool; default 5
+#httpAccess.connectionTimeToLive
+# Unit of the timeToLive parameter as a java TimeUnit constant; default MINUTES
+#httpAccess.connectionTimeToLive.unit
+# Connection idle timeout; default 1
+#httpAccess.connectionIdleTimeout
+# Unit of idleTimeout parameter as a java TimeUnit constant; default MINUTES
+#httpAccess.connectionIdleTimeout.unit
 ```
 
 
-
-[Maven documentation and reports](http://dev.lutece.paris.fr/plugins/library-httpaccess/)
+[Maven documentation and reports](https://dev.lutece.paris.fr/plugins/library-httpaccess/)
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
          <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.5.1</version>
+            <version>5.6</version>
 	</dependency>
         <dependency>
 	    <groupId>com.squareup.okhttp3</groupId>

--- a/src/java/fr/paris/lutece/util/httpaccess/HttpAccessService.java
+++ b/src/java/fr/paris/lutece/util/httpaccess/HttpAccessService.java
@@ -34,12 +34,14 @@
 package fr.paris.lutece.util.httpaccess;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.ConnectionConfig.Builder;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.DefaultRedirectStrategy;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.core5.util.Timeout;
 
 /**
@@ -124,24 +126,36 @@ public class HttpAccessService implements ResponseStatusValidator
                     Integer.parseInt( _httpClientConfiguration.getProxyPort( ) ), _httpClientConfiguration.getNoProxyFor( ) ) );
         }
 
-        if ( _httpClientConfiguration.getConnectionPoolMaxConnectionPerHost( ) != null
-                || _httpClientConfiguration.getConnectionPoolMaxTotalConnection( ) != null )
+        PoolingHttpClientConnectionManagerBuilder  connectionManagerbuilder = PoolingHttpClientConnectionManagerBuilder.create( );
+
+        if ( _httpClientConfiguration.getConnectionPoolMaxConnectionPerHost( ) != null )
         {
-            PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager( );
-
-            if ( _httpClientConfiguration.getConnectionPoolMaxConnectionPerHost( ) != null )
-            {
-                connectionManager.setDefaultMaxPerRoute( _httpClientConfiguration.getConnectionPoolMaxConnectionPerHost( ) );
-
-            }
-
-            if ( _httpClientConfiguration.getConnectionPoolMaxTotalConnection( ) != null )
-            {
-                connectionManager.setMaxTotal( _httpClientConfiguration.getConnectionPoolMaxTotalConnection( ) );
-            }
-
-            clientBuilder.setConnectionManager( connectionManager );
+            connectionManagerbuilder.setMaxConnPerRoute( _httpClientConfiguration.getConnectionPoolMaxConnectionPerHost( ) );
         }
+
+        if ( _httpClientConfiguration.getConnectionPoolMaxTotalConnection( ) != null )
+        {
+            connectionManagerbuilder.setMaxConnTotal( _httpClientConfiguration.getConnectionPoolMaxTotalConnection( ) );
+        }
+
+        if ( _httpClientConfiguration.getConnectionTimeToLive( ) != null || _httpClientConfiguration.getConnectionIdleTimeout( ) != null )
+        {
+            Builder connectionConfigBuilder = ConnectionConfig.custom( );
+
+            if ( _httpClientConfiguration.getConnectionTimeToLive( ) != null )
+            {
+                connectionConfigBuilder.setTimeToLive( _httpClientConfiguration.getConnectionTimeToLive( ),
+                        _httpClientConfiguration.getConnectionTimeToLiveUnit( ) );
+            }
+            if ( _httpClientConfiguration.getConnectionIdleTimeout( ) != null )
+            {
+                connectionConfigBuilder.setIdleTimeout( _httpClientConfiguration.getConnectionIdleTimeout( ),
+                        _httpClientConfiguration.getConnectionIdleTimeoutUnit( ) );
+            }
+            connectionManagerbuilder.setDefaultConnectionConfig( connectionConfigBuilder.build( ) );
+        }
+
+        clientBuilder.setConnectionManager( connectionManagerbuilder.build( ) );
 
         if ( _httpClientConfiguration.getSocketTimeout( ) != null || _httpClientConfiguration.getConnectionTimeout( ) != null )
         {

--- a/src/java/fr/paris/lutece/util/httpaccess/HttpClientConfiguration.java
+++ b/src/java/fr/paris/lutece/util/httpaccess/HttpClientConfiguration.java
@@ -33,6 +33,8 @@
  */
 package fr.paris.lutece.util.httpaccess;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * The Class HttpClientConfiguration.
  */
@@ -80,6 +82,18 @@ public class HttpClientConfiguration
 
     /** The _str connection pool max connection per host. */
     private Integer _nConnectionPoolMaxConnectionPerHost;
+
+    /** The connection time to live in the pool */
+    private Long _nConnectionTimeToLive;
+
+    /** The unit of the _nConnectionTimeToLive field */
+    private TimeUnit _connectionTimeToLiveUnit;
+
+    /** The connection idle timeout in the pool */
+    private Long _nConnectionIdleTimeout;
+
+    /** the unit of the _nConnectionIdleTimeout field */
+    private TimeUnit _connectionIdleTimeoutUnit;
 
     /**
      * Gets the proxy host.
@@ -398,4 +412,95 @@ public class HttpClientConfiguration
         this._nConnectionPoolMaxConnectionPerHost = nConnectionPoolMaxConnectionPerHost;
     }
 
+    /**
+     * Gets the connection time to live in the pool. The unit of this value is available via {@link #getConnectionTimeToLiveUnit}.
+     * 
+     * @return the connection time to live in the pool
+     * @since 3.0.5
+     */
+    public Long getConnectionTimeToLive( )
+    {
+        return _nConnectionTimeToLive;
+    }
+
+    /**
+     * Sets the connection time to live in the pool. The unit of this value is settable via {@link #setConnectionTimeToLiveUnit}.
+     * 
+     * @param nConnectionTimeToLive
+     *            connection time to live in the pool
+     * @since 3.0.5
+     */
+    public void setConnectionTimeToLive( Long nConnectionTimeToLive )
+    {
+        this._nConnectionTimeToLive = nConnectionTimeToLive;
+    }
+
+    /**
+     * Gets the connection time to live unit
+     * 
+     * @return the connection time to live unit
+     * @since 3.0.5
+     */
+    public TimeUnit getConnectionTimeToLiveUnit( )
+    {
+        return _connectionTimeToLiveUnit;
+    }
+
+    /**
+     * Sets the connection time to live unit
+     * 
+     * @param connectionTimeToLiveUnit
+     *            the connection time to live unit
+     * @since 3.0.5
+     */
+    public void setConnectionTimeToLiveUnit( TimeUnit connectionTimeToLiveUnit )
+    {
+        this._connectionTimeToLiveUnit = connectionTimeToLiveUnit;
+    }
+
+    /**
+     * Gets the connection idle timeout in the pool. The unit of this value is available via {@link #getConnectionIdleTimeoutUnit}.
+     * 
+     * @return the connection idle timeout in the pool
+     * @since 3.0.5
+     */
+    public Long getConnectionIdleTimeout( )
+    {
+        return _nConnectionIdleTimeout;
+    }
+
+    /**
+     * Sets the connection idle timeout in the pool. The unit of this value is settable via {@link #setConnectionIdleTimeoutUnit}.
+     * 
+     * @param nConnectionIdleTimeout
+     *            connection idle timeout in the pool
+     * @since 3.0.5
+     */
+    public void setConnectionIdleTimeout( Long nConnectionIdleTimeout )
+    {
+        this._nConnectionIdleTimeout = nConnectionIdleTimeout;
+    }
+
+    /**
+     * Gets the connection idle timeout unit
+     * 
+     * @return the connection idle timeout unit
+     * @since 3.0.5
+     */
+    public TimeUnit getConnectionIdleTimeoutUnit( )
+    {
+        return _connectionIdleTimeoutUnit;
+    }
+
+    /**
+     * Sets the connection idle timeout unit
+     * 
+     * @param connectionTimeToLiveUnit
+     *            the connection idle timeout unit
+     * @since 3.0.5
+     */
+    public void setConnectionIdleTimeoutUnit( TimeUnit connectionIdleTimeoutUnit )
+    {
+        this._connectionIdleTimeoutUnit = connectionIdleTimeoutUnit;
+    }
 }

--- a/src/java/fr/paris/lutece/util/httpaccess/PropertiesHttpClientConfiguration.java
+++ b/src/java/fr/paris/lutece/util/httpaccess/PropertiesHttpClientConfiguration.java
@@ -33,6 +33,8 @@
  */
 package fr.paris.lutece.util.httpaccess;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.lang3.StringUtils;
 
 import fr.paris.lutece.portal.service.util.AppLogService;
@@ -85,6 +87,18 @@ public class PropertiesHttpClientConfiguration extends HttpClientConfiguration
     /** The Constant PROPERTY_CONNECTION_POOL_MAX_TOTAL_CONNECTION_PER_HOST. */
     private static final String PROPERTY_CONNECTION_POOL_MAX_TOTAL_CONNECTION_PER_HOST = "httpAccess.connectionPoolMaxConnectionsPerHost";
 
+    /** The Constant PROPERTY_CONNECTION_TIME_TO_LIVE */
+    private static final String PROPERTY_CONNECTION_TIME_TO_LIVE = "httpAccess.connectionTimeToLive";
+
+    /** The Constant PROPERTY_CONNECTION_TIME_TO_LIVE_UNIT */
+    private static final String PROPERTY_CONNECTION_TIME_TO_LIVE_UNIT = "httpAccess.connectionTimeToLive.unit";
+
+    /** The Constant PROPERTY_CONNECTION_IDLE_TIMEOUT */
+    private static final String PROPERTY_CONNECTION_IDLE_TIMEOUT = "httpAccess.connectionIdleTimeout";
+
+    /** The Constant PROPERTY_CONNECTION_IDLE_TIMEOUT_UNIT */
+    private static final String PROPERTY_CONNECTION_IDLE_TIMEOUT_UNIT = "httpAccess.connectionIdleTimeout.unit";
+
     public PropertiesHttpClientConfiguration( )
     {
         this.setProxyHost( AppPropertiesService.getProperty( PROPERTY_PROXY_HOST ) );
@@ -129,7 +143,7 @@ public class PropertiesHttpClientConfiguration extends HttpClientConfiguration
         }
         catch( NumberFormatException e )
         {
-            AppLogService.error( "Error during initialisation of Connection Pool Maxt Total Connection ", e );
+            AppLogService.error( "Error during initialisation of Connection Pool Max Total Connection ", e );
         }
         try
         {
@@ -141,6 +155,28 @@ public class PropertiesHttpClientConfiguration extends HttpClientConfiguration
         catch( NumberFormatException e )
         {
             AppLogService.error( "Error during initialisation of Connection Pool Maxt Total Connection Per Host ", e );
+        }
+        this.setConnectionIdleTimeout( AppPropertiesService.getPropertyLong( PROPERTY_CONNECTION_IDLE_TIMEOUT, 1 ) );
+        try
+        {
+            this.setConnectionIdleTimeoutUnit(
+                    TimeUnit.valueOf( AppPropertiesService.getProperty( PROPERTY_CONNECTION_IDLE_TIMEOUT_UNIT, "MINUTES" ).trim( ) ) );
+        }
+        catch( IllegalArgumentException e )
+        {
+            AppLogService.error( "Error during initialisation of Connection Pool idle timeout unit", e );
+            this.setConnectionIdleTimeout( null );
+        }
+        this.setConnectionTimeToLive( AppPropertiesService.getPropertyLong( PROPERTY_CONNECTION_TIME_TO_LIVE, 5 ) );
+        try
+        {
+            this.setConnectionTimeToLiveUnit(
+                    TimeUnit.valueOf( AppPropertiesService.getProperty( PROPERTY_CONNECTION_TIME_TO_LIVE_UNIT, "MINUTES" ).trim( ) ) );
+        }
+        catch( IllegalArgumentException e )
+        {
+            AppLogService.error( "Error during initialisation of Connection Pool time to live unit", e );
+            this.setConnectionTimeToLive( null );
         }
     }
 }

--- a/src/site/fr/xdoc/index.xml
+++ b/src/site/fr/xdoc/index.xml
@@ -16,10 +16,9 @@
                 </p>
             </subsection>
             <subsection name="Configuration">
-                <p>
-                    La configuration est définie dans le fichier <code>WEB-INF/conf/plugins/httpaccess.properties</code>.
-                    <pre>
-################################################################
+                <p>La configuration est définie dans le fichier <code>WEB-INF/conf/plugins/httpaccess.properties</code>.</p>
+
+<pre>################################################################
 ## Proxy settings
 httpAccess.proxyHost=
 httpAccess.proxyPort=
@@ -41,8 +40,22 @@ httpAccess.connexionTimeout=
 httpAccess.socketTimeout=
 #Http responses code authorized (200->OK,201 ->Created,...)
 httpAccess.responsesCodeAuthorized=200,201,202,203,204,205,206,207,210
-                    </pre>
-                </p>
+
+# Connection pool configuration
+
+# Maximum total number of connections in the pool; optional
+#httpAccess.connectionPoolMaxTotalConnections=
+# Maximum number of connections per host in the pool; optional
+#httpAccess.connectionPoolMaxConnectionsPerHost
+# Time to live of a connection in the pool; default 5
+#httpAccess.connectionTimeToLive
+# Unit of the timeToLive parameter as a java TimeUnit constant; default MINUTES
+#httpAccess.connectionTimeToLive.unit
+# Connection idle timeout; default 1
+#httpAccess.connectionIdleTimeout
+# Unit of idleTimeout parameter as a java TimeUnit constant; default MINUTES
+#httpAccess.connectionIdleTimeout.unit</pre>
+
             </subsection>
         </section>
     </body>

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -16,10 +16,9 @@
                 </p>
             </subsection>
             <subsection name="Configuration">
-                <p>
-                    Configuration is defined in the <code>WEB-INF/conf/plugins/httpaccess.properties</code>.
-                    <pre>
-################################################################
+                <p>Configuration is defined in the <code>WEB-INF/conf/plugins/httpaccess.properties</code>.</p>
+
+<pre>################################################################
 ## Proxy settings
 httpAccess.proxyHost=
 httpAccess.proxyPort=
@@ -41,8 +40,22 @@ httpAccess.connexionTimeout=
 httpAccess.socketTimeout=
 #Http responses code authorized (200->OK,201 ->Created,...)
 httpAccess.responsesCodeAuthorized=200,201,202,203,204,205,206,207,210
-                    </pre>
-                </p>
+
+# Connection pool configuration
+
+# Maximum total number of connections in the pool; optional
+#httpAccess.connectionPoolMaxTotalConnections=
+# Maximum number of connections per host in the pool; optional
+#httpAccess.connectionPoolMaxConnectionsPerHost
+# Time to live of a connection in the pool; default 5
+#httpAccess.connectionTimeToLive
+# Unit of the timeToLive parameter as a java TimeUnit constant; default MINUTES
+#httpAccess.connectionTimeToLive.unit
+# Connection idle timeout; default 1
+#httpAccess.connectionIdleTimeout
+# Unit of idleTimeout parameter as a java TimeUnit constant; default MINUTES
+#httpAccess.connectionIdleTimeout.unit</pre>
+
             </subsection>
         </section>
     </body>

--- a/src/test/java/fr/paris/lutece/util/httpaccess/HttpAccessTest.java
+++ b/src/test/java/fr/paris/lutece/util/httpaccess/HttpAccessTest.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.lang3.StringUtils;
@@ -502,12 +503,15 @@ public class HttpAccessTest
         HttpClientConfiguration configuration = new HttpClientConfiguration( );
         configuration.setConnectionTimeout( 10000 );
         configuration.setSocketTimeout( 100000 );
-        // onfiguration.setProxyHost("");
+        // configuration.setProxyHost("");
         configuration.setNoProxyFor( "*.paris.mdp" );
         configuration.setProxyPort( "8080" );
-        configuration.setConnectionPoolEnabled( true );
         configuration.setConnectionPoolMaxTotalConnection( 3 );
         configuration.setConnectionPoolMaxConnectionPerHost( 3 );
+        configuration.setConnectionIdleTimeout( 5L );
+        configuration.setConnectionIdleTimeoutUnit( TimeUnit.valueOf( "SECONDS" ) );
+        configuration.setConnectionTimeToLive( 10L );
+        configuration.setConnectionTimeToLiveUnit( TimeUnit.valueOf( "SECONDS" ) );
 
         Map<String, String> mapHeaders = new HashMap<String, String>( );
         Map<String, String> mapHeadersResponse = new HashMap<String, String>( );


### PR DESCRIPTION
To avoid having stall connections in the connection pool, provide configuration for the timetolive and idletimout properties of the connection manager.
The timetolive defaults to 5 minutes, and the idletimeout defaults to 1 minute.